### PR TITLE
Updated to expo 35 and shadow-cljs 2.8.81.

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "slug": "reagent-expo",
     "privacy": "public",
     "entryPoint": "./app/index.js",
-    "sdkVersion": "33.0.0",
+    "sdkVersion": "35.0.0",
     "platforms": [
       "ios",
       "android",

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^33.0.0",
-    "react": "16.8.6",
-    "react-dom": "^16.8.6",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
-    "react-native-web": "^0.11.5"
+    "expo": "^35.0.0",
+    "react": "16.8.3",
+    "react-dom": "16.8.3",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
+    "react-native-web": "^0.11.7"
   },
   "devDependencies": {
-    "babel-preset-expo": "^5.0.0",
-    "shadow-cljs": "^2.8.45"
+    "babel-preset-expo": "^7.0.0",
+    "shadow-cljs": "^2.8.81"
   },
   "private": true
 }


### PR DESCRIPTION
The other PR was accidentally made using a stale fork. Remade the fork and updated.
Tested on web and ios.
Fixes https://github.com/thheller/reagent-expo/issues/7